### PR TITLE
Add ATmega32 as tested

### DIFF
--- a/src/urboot.c
+++ b/src/urboot.c
@@ -34,6 +34,7 @@
  *  - ATmega1284P (UrclockMega, MoteinoMega)
  *  - ATmega2560 (Mega R3)
  *  - ATmega162
+ *  - ATmega32 (MightyCore)
  *  - ATtiny88 (MH Tiny)
  *  - ATtiny85 (Digispark)
  *  - ATtiny167 (Digispark Pro)

--- a/src/urboot.c
+++ b/src/urboot.c
@@ -62,7 +62,7 @@
  *   atmega165a atmega165p atmega165pa atmega168 atmega168a atmega168p atmega168pa atmega168pb
  *   atmega169 atmega169a atmega169p atmega169pa atmega16a atmega16hva atmega16hva2 atmega16hvb
  *   atmega16hvbrevb atmega16m1 atmega16u2 atmega16u4 atmega2561 atmega2564rfr2 atmega256rfr2
- *   atmega32 atmega323 atmega324a atmega324p atmega324pa atmega324pb atmega325 atmega3250
+ *   atmega323 atmega324a atmega324p atmega324pa atmega324pb atmega325 atmega3250
  *   atmega3250a atmega3250p atmega3250pa atmega325a atmega325p atmega325pa atmega328 atmega328pb
  *   atmega329 atmega3290 atmega3290a atmega3290p atmega3290pa atmega329a atmega329p atmega329pa
  *   atmega32a atmega32c1 atmega32hvb atmega32hvbrevb atmega32m1 atmega32u2 atmega32u4 atmega32u6


### PR DESCRIPTION
Hi again,

Since ATmega32 works great now with Urboot, I was wondering if you would be open to mentioning it (and the MightyCore) as supported devices.  It'd be great if you approve this, but I would also understand if you decide to reject this PR, for example if you like to keep the list short, or only include the chips that you've personally tested.

Thanks a bunch! 😄 