### PR TITLE
add dockerfile for container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 ubuntu:jammy
+
+RUN apt-get update \
+	&& apt-get install -y build-essential perl \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+RUN PERL_MM_USE_DEFAULT=1 cpan -T install File::Basename Capture::Tiny POSIX Scalar::Util Getopt::Long
+
+ENTRYPOINT ["/usr/bin/make"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ taken, it is easy to create own bootloaders with commands such as
  $ make MCU=atmega328p F_CPU=16000000L BAUD_RATE=115200 EEPROM=1 URPROTOCOL=1 \
    LED=AtmelPB1 SFMCS=AtmelPB0 DUAL=1 FRILLS=7 NAME=moteino-dual
 ```
+
+Alternatively, the Dockerfile may be built and used to build binaries on other systems:
+```
+ $ docker run --platform linux/amd64 -v "$(pwd)/src":/src --rm -it $(docker build -q .) \
+   MCU=atmega328p F_CPU=16000000L BAUD_RATE=115200 EEPROM=1 URPROTOCOL=1 \
+   LED=AtmelPB1 SFMCS=AtmelPB0 DUAL=1 FRILLS=7 NAME=moteino-dual
+```
 More detailed information here: [`make` options](https://github.com/stefanrueger/urboot/blob/main/docs/makeoptions.md)
 
 <p id="pre-compiled"></p>


### PR DESCRIPTION
Adds a small Dockerfile definition to create a Linux build environment on non-linux machines + provides documentation in the README to build w/ zero setup.

Tested on aarch64 macOS (using Docker to simulate x86-64 linux for precompiled AVR toolchain) and x86-64 linux.

From the repo root directory:
```
docker run --platform linux/amd64 -v "$(pwd)/src":/src --rm -it $(docker build -q .) all
```
is equivalent to `make all`.

(closes #15)